### PR TITLE
Assume 2.7.1 has the same profile as 2.7

### DIFF
--- a/inc/Ver2Func.pm
+++ b/inc/Ver2Func.pm
@@ -549,6 +549,7 @@ sub new {
     my ( $class, $version ) = @_;
 
     $version = '1.16' if $version eq '1.16.1';
+    $version = '2.7' if $version eq '2.7.1';
 
     defined( my $vers_idx = $index{$version} )
       or croak( "Unsupported GSL version!!! : $version" );
@@ -579,7 +580,7 @@ sub versions {
     ( undef, my $cur_ver ) = @_;
 
     return @versions unless defined $cur_ver;
-
+    $cur_ver = '2.7' if $cur_ver eq '2.7.1';
     defined( my $idx = $index{$cur_ver} )
       or croak( "unsupported version: $cur_ver" );
 


### PR DESCRIPTION
Looking at perltesters, most of the recent builds of this are report failing. It seem to be because most distributions are installed GSL 2.7.1 and not 2.7. I have assumed that the interface for the two versions is the same and essentially done the same trick as was done with version  1.16.1, that is  to  treat 2.7.1 as 2.7.  This might not be the correct solution. The tests still fail. 