### PR TITLE
Add comment to clarify build failures on macOS

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -183,6 +183,9 @@ jobs:
     strategy:
       matrix:
         perl: [38, 36]
+        #gsl: [2.7, 2.6]
+        # NOTE: on macos we will not build against a pre-installed gsl, this will cause
+        #     Build.PL to download the latest gsl version from the internet instead
     steps:
       - uses: actions/checkout@v4
       - name: set environment variables


### PR DESCRIPTION
On macOS the GitHub action will build against the latest version of GSL. Since we do not support GSL 2.8 yet (the latest version), it is expected that the macOS steps will fail.