### PR TITLE
swig/Multiroots.i: fix build failure with gcc 14.

### DIFF
--- a/swig/Multiroots.i
+++ b/swig/Multiroots.i
@@ -5,7 +5,7 @@
 %typemap(in) gsl_multiroot_function * {
     gsl_multiroot_function *f;
     /* stub */
-    $1 = &f;
+    $1 = (gsl_multiroot_function *)&f;
 }
 
 %{


### PR DESCRIPTION
As identified in [Debian bug #1075182], Math::GSL fails to build with gcc 14 with the following kind of symptoms due to a number of warnings in the C compiler now gone fatal by default:

	xs/Multiroots_wrap.2.8.c:2950:12:
	error: assignment to ‘gsl_multiroot_function *’
	       {aka ‘struct gsl_multiroot_function_struct *’}
	       from incompatible pointer type ‘gsl_multiroot_function **’
	       {aka ‘struct gsl_multiroot_function_struct **’}
	       [-Wincompatible-pointer-types]
	 2950 |       arg1 = &f;
	      |            ^

This change fixes/workarounds the issue by casting the &f pointer to the expected type.  Other approaches trying to fix the native type of f straight away result in a segmentation faults while running tests, and any other approaches were anything but obvious due to entanglement with swig, but maybe there is something more appropriate than casting.

[Debian bug #1075182]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075182